### PR TITLE
Restructuring and added existing brew file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,29 +7,40 @@ Brew It is an automated installer for [Homebrew][1] inspired by [Bash-It][2]
 
 1. Clone Brew It to you home directory
 
-  ```
-  git clone git@github.com:jimmynotjim/brew-it.git ~/.brew_it
-  ```
+    ```
+    git clone git@github.com:jimmynotjim/brew-it.git ~/.brew_it
+    ```
 
-2. Check out the available formulas in `/formulas` and make adjustments for your own needs
+1. Check out the available formulas in `/formulas` and make adjustments for your own needs
 
-3. Run the installer
+1. Run the installer
 
-  ```
-  ~/.brew_it/install.sh
-  ```
+    ```
+    ~/.brew_it/install.sh
+    ```
 
+1. Follow the instructions
+
+1. Enjoy
 
 ## Usage
 
-If Homebrew isn't already installed on your system, Brew It will ask if you'd like to install it, but it's a rhetorical question, you need Homebrew to use Brew It. From there it will give you the choice of installing all, some or none of the available packages. If you choose all, it will run through and add all of the included formulas to your `.brewrc`. If you choose some, it will ask you which of the formula types to include in your `.brewrc`. If you choose none it will exit the process.
+If Homebrew isn't already installed on your system, Brew It will ask if you would like to install it, but it's a rhetorical question, you need Homebrew to use Brew It. If it is installed Brew It will run `brew update` to get the latest packages.
 
-The included formulas are broken up into their main types. Not every formula is included within each type and some are included but commented out to save you from searching for them. It's assumed your needs are not my needs, and you will edit the files within `/formulas` to fit your system. It's best to create a new branch with your edits, so that you don't lose them from pulling from the repo in the future. If you're unsure if you need a formula, you should most likely comment it out to avoid installing it.
+From here Brew It will check for an existing `.brewrc` file in your home directory. If it finds one, you have the option of running the installer with it or replacing it with a new `.brewrc` file built by Brew It.
+
+If you don't have an existing `.brewrc` or choose to build a new file, the installer will ask if you'd like to install all, some or none of the included formulas. Typically you want to choose `all`, but the other options are available to you if you need them.
+
+After Brew It builds your `.brewrc` file it will give you the choice to continue the installation or exit and review the file. If you made a mistake or you want to be absolutely sure what you agreed to install, now's your chance to take a look.
+
+Finally, Brew It will run the appropriate commands for each of the formula types and complete your installation.
 
 
 ## Notes
 
-When running the installer Brew It will create a new `.brewrc` and backup your existing `.brewrc` as `.brewrc.bak` if one exists. If you need to keep an existing brewfile it's encouraged that you make a copy outside your home directory or rename it.
+1. The included formulas are broken up into their main types. Not every formula is included within each type and some are included but commented out to save you from searching for them. It's assumed your needs are not my needs, and you will edit the files within `/formulas` to fit your system. It's best to create a new branch with your edits, so that you don't lose them from pulling from the repo in the future. If you're unsure if you need a formula, you should most likely comment it out to avoid installing it.
+
+1. When running the installer Brew It will check for an existing `.brewrc` and back it up as `.brewrc.bak` if you choose to. If you need to keep an existing brewfile it's encouraged that you make a copy outside your home directory or rename it.
 
 
 ## License
@@ -39,15 +50,16 @@ Brew It is Copyright &copy; 2012-2015 James Wilson, released under the [MIT lice
 
 ## Version
 
-Latest version is 0.2.0 and may be unstable. Make sure to view [the changelog][4] before updating.
+Latest version is 0.2.0 and may be unstable. Make sure to view [the changelog][4] before updating. If you find errors, please repot them to the [issues page].
 
 
 ## Author
 
-[James Wilson (@jimmynotjim)][5]
+[James Wilson (@jimmynotjim)][6]
 
 [1]: http://brew.sh/
 [2]: https://github.com/revans/bash-it
 [3]: https://github.com/jimmynotjim/brew-it/blob/master/LICENSE-MIT
 [4]: https://github.com/jimmynotjim/brew-it/blob/master/CHANGELOG.md
-[5]: http://github.com/jimmynotjim
+[5]: https://github.com/jimmynotjim/brew-it/issues
+[6]: http://github.com/jimmynotjim

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ function review_brewfile() {
       break
       ;;
     [nN])
-      echo "Quitting installation, review and rerun when you're ready to install (and respond yes when prompted to install from existing .brewrc)."
+      echo "Quitting installation, review and rerun install script when ready (respond yes when prompted to install from existing .brewrc)."
       open -e .brewrc
       exit
       break

--- a/install.sh
+++ b/install.sh
@@ -1,34 +1,31 @@
 BREW_IT="$HOME/.brew_it"
 
-echo "Checking usr/local for Homebrew"
-test ! -w /usr/local/Library/brew.rb &&
-  while true
-  do
-    read -p "Homebrew is missing from usr/local, would you like to install it? [Y/N] " RESP
+function check_for_homebrew() {
+  echo "Checking usr/local for Homebrew"
+  test -e /usr/local/Library/brew.rb
+  return $?
+}
 
-    case $RESP
-      in
-      [yY])
-        echo "Installing Homebrew"
-        ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-        echo "Updating Homebrew"
-        brew update
-        break
-        ;;
-      [nN])
-        break
-        ;;
-      *)
-        echo "Please enter Y or N"
-    esac
-  done
+function install_homebrew() {
+  echo "Installing Homebrew"
+  ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+}
 
-echo "Searching for existing .brewrc"
-test -w $HOME/.brewrc &&
-  cp $HOME/.brewrc $HOME/.brewrc.bak &&
+function check_for_brewfile() {
+  echo "Searching for existing .brewrc"
+  test -e $HOME/.brewrc
+  return $?
+}
+
+function backup_brewfile() {
+  cp $HOME/.brewrc $HOME/.brewrc.bak
   echo "Your original .brewrc has been backed up to .brewrc.bak"
+}
 
-cp $HOME/.brew_it/template/brewrc.template.bash $HOME/.brewrc
+function create_brewfile() {
+  cp $HOME/.brew_it/template/brewrc.template.bash $HOME/.brewrc
+  echo "Created new .brewrc"
+}
 
 function load_all() {
   for src in $BREW_IT/formulas/*;
@@ -61,6 +58,55 @@ function load_some() {
   done
 }
 
+function write_brewfile {
+  while true
+  do
+    read -p "Would you like to enable all, some, or none of the brew formulas? (all/some/none/) " RESP
+    case $RESP
+    in
+    some)
+      load_some
+      break
+      ;;
+    all)
+      load_all
+      break
+      ;;
+    none)
+      echo "Exiting"
+      break
+      ;;
+    *)
+      echo "Unknown choice. Please enter all, some, or none"
+      continue
+      ;;
+    esac
+  done
+
+  echo "Completed building .brewrc"
+}
+
+function review_brewfile() {
+  while true
+  do
+    read -p "Ready to install your formulas (Select NO to review your .brewrc) [Y/N] " RESP
+    case $RESP in
+    [yY])
+      break
+      ;;
+    [nN])
+      echo "Quitting installation, review and rerun when you're ready to install (and respond yes when prompted to install from existing .brewrc)."
+      open -e .brewrc
+      exit
+      break
+      ;;
+    *)
+      echo "Please choose Y or N."
+      ;;
+    esac
+  done
+}
+
 function verify_formula() {
   IFS=', ' read -a args <<< "$line"
   cmd=${args[0]}
@@ -71,57 +117,95 @@ function verify_formula() {
     p=${args[2]}
   fi
   if [ "$cmd" = "tap" ]; then
-    verify=true
+    return 0
   elif [ "$cmd" = "install" ]; then
     brew info $p > /dev/null 2> /dev/null
-
-    if [ "$?" = 0 ];then
-      verify=true
-    else
-      verify=false
-    fi
+    return $?
   elif [ "$cmd" = "cask" ]; then
     cmd=${args[1]}
     p=${args[2]}
     if [ "$cmd" = "alfred" ]; then
-      verify=true
+      return 0
     else
       brew cask info $p > /dev/null 2> /dev/null
-
-      if [ "$?" = 0 ];then
-        verify=true
-      else
-        verify=false
-      fi
+      return $?
     fi
   fi
 }
 
 function install_formulas() {
+  while read line;
+  do
+    line=${line%%#*}
+    if [ "$line" = "" ];then
+      continue
+    fi
+
+    verify_formula line
+    formula_exists=$?
+
+    if [ "$formula_exists" = 0 ]; then
+      echo ${p}
+      #brew ${line}
+    else
+      echo "package missing: $p"
+    fi
+  done < $HOME/.brewrc
+  echo "Installation is complete, enjoy your new machine!"
+}
+
+
+## Lets do this!
+
+
+## Check for Homebrew, update if it's installed and ask to install if it's missing
+check_for_homebrew
+homebrew_installed=$?
+
+if [ "$homebrew_installed" = 0 ]; then
+  echo 'homebrew installed, updating homebrew'
+  brew update
+else
   while true
   do
-    read -p "Completed building .brewrc, ready to install your formulas (Select NO to review your .brewrc) [Y/N] " RESP
+    read -p "Homebrew is missing from usr/local, would you like to install it? [Y/N] " RESP
+    case $RESP
+      in
+      [yY])
+        install_homebrew
+        break
+        ;;
+      [nN])
+        echo "Homebrew is required to complete install, please visit http://brew.sh/ to install manually"
+        exit
+        break
+        ;;
+      *)
+        echo "Please enter Y or N"
+    esac
+  done
+fi
+
+
+## Check for .brewrc, ask to install or overwrite if it exists and create new .brewrc if it doesn't
+check_for_brewfile
+brewfile_exists=$?
+
+if [ "$brewfile_exists" = 0 ]; then
+  while true
+  do
+    read -p ".brewrc already exists. Would you like to install from your existing .brewrc? [Y/N] " RESP
     case $RESP in
     [yY])
-      while read line;
-      do
-        line=${line%%#*}
-        if [ "$line" = "" ];then
-          continue
-        fi
-        verify_formula line
-        if [ "$verify" = true ]; then
-          brew ${line}
-        else
-          echo "package missing: $p"
-        fi
-      done < $HOME/.brewrc
-      echo "Installation is complete, enjoy your new machine!"
-        break
+      install_formulas
+      break
       ;;
     [nN])
-      echo "Quitting installation, review and run \"brew bundle ~/.brewrc\" when you are ready to install."
-      open -e .brewrc
+      backup_brewfile
+      create_brewfile
+      write_brewfile
+      review_brewfile
+      install_formulas
       break
       ;;
     *)
@@ -129,31 +213,12 @@ function install_formulas() {
       ;;
     esac
   done
-}
+else
+  create_brewfile
+  write_brewfile
+  review_brewfile
+  install_formulas
+fi
 
-while true
-do
-  read -p "Would you like to enable all, some, or none of the brew formulas? (all/some/none) " RESP
-  case $RESP
-  in
-  some)
-    load_some
-    install_formulas
-    break
-    ;;
-  all)
-    load_all
-    install_formulas
-    break
-    ;;
-  none)
-    echo "Exiting"
-    break
-    ;;
-  *)
-    echo "Unknown choice. Please enter all, some, or none"
-    continue
-    ;;
-  esac
-done
+
 

--- a/install.sh
+++ b/install.sh
@@ -145,8 +145,7 @@ function install_formulas() {
     formula_exists=$?
 
     if [ "$formula_exists" = 0 ]; then
-      echo ${p}
-      #brew ${line}
+      brew ${line}
     else
       echo "package missing: $p"
     fi

--- a/install.sh
+++ b/install.sh
@@ -65,10 +65,12 @@ function write_brewfile {
     case $RESP
     in
     some)
+      create_brewfile
       load_some
       break
       ;;
     all)
+      create_brewfile
       load_all
       break
       ;;
@@ -202,7 +204,6 @@ if [ "$brewfile_exists" = 0 ]; then
       ;;
     [nN])
       backup_brewfile
-      create_brewfile
       write_brewfile
       review_brewfile
       install_formulas
@@ -214,7 +215,6 @@ if [ "$brewfile_exists" = 0 ]; then
     esac
   done
 else
-  create_brewfile
   write_brewfile
   review_brewfile
   install_formulas

--- a/install.sh
+++ b/install.sh
@@ -74,6 +74,7 @@ function write_brewfile {
       ;;
     none)
       echo "Exiting"
+      exit
       break
       ;;
     *)


### PR DESCRIPTION
This update restructures the tasks and checkers into individual functions for easier reuse throughout the project. It also adds an option to install from an existing `.brewrc` if one exists rather than creating a new one. Prior, if you had your brew file just how you liked it and ran the installer it would start by unnecessarily backing up and overwriting the brew file.
